### PR TITLE
preset-es2015

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "leanengine": "^1.1.0",
     "lodash": "^4.13.1",
     "node-fetch": "^1.5.3",
+    "babel-preset-es2015": "^6.10.0",
     "peer": "^0.2.8",
     "ws": "^1.1.1"
   },


### PR DESCRIPTION
否则报错“ Couldn't find preset "es2015" relative to directory…”。
